### PR TITLE
v2.1.0 - Update syntax to support any order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## [2.1.0] - 2023-07-22
 ### Added
-- The CHANGELOG.md file.
+- Syntax support for wrinting the definitions (`I`, `F`, `compose` and the tape) in any order.
+- Error handling for when there are no final states or no intial state.
+
+### Changed
+- Updated minor version of dependencies
+- Now parsing an instruction can return an error if the instruction is not valid.
+- Now defining instructions is optional. If no instructions are defined, the turing machine will be empty apart from the composed libraries.
+
+### Fixed
+- Syntax support for the movements `I` (Izquierda) and `D` (Derecha).
+- The `finished` function now takes into account the movement in addition to whether the state is final or not.
 
 ## [2.0.2] - 2023-07-18
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turing-lib"
-version = "2.0.3"
+version = "2.1.0"
 edition = "2021"
 authors = ["Marcos Gutiérrez Alonso <uo272509@uniovi.es>"]
 repository = "https://github.com/turing-marcos/turing-lib"
@@ -12,8 +12,8 @@ exclude = ["**/Examples/"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pest = "^2.5"
-pest_derive = "^2.5"
-log = "0.4.17"
-env_logger = "0.10.0"
+pest = "^2.7"
+pest_derive = "^2.7"
+log = "^0.4"
+env_logger = "^0.10"
 serde = { version = "^1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Check out the [online demo](https://turing.coldboard.net) (here is [the code](ht
 Add the following to your `Cargo.toml` file under `[dependencies]`:
 
 ```toml
-turing_lib = "^2.0"
+turing_lib = "^2.1"
 ```
 or
 ```toml

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -81,12 +81,15 @@ impl TuringInstruction {
         let movement = match code.next() {
             Some(s) => match Movement::from_str(s.as_span().as_str()) {
                 Ok(m) => m,
-                Err(message) => return Err(CompilerError::SyntaxError { 
-                    position: ErrorPosition::from(&s), 
-                    message,
-                    code: String::from(s.as_str()), 
-                    expected: Rule::movement, 
-                    found: None })
+                Err(message) => {
+                    return Err(CompilerError::SyntaxError {
+                        position: ErrorPosition::from(&s),
+                        message,
+                        code: String::from(s.as_str()),
+                        expected: Rule::movement,
+                        found: None,
+                    })
+                }
             },
             None => panic!("The instruction lacks an initial state"),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub struct Library {
 }
 
 impl Library {
-    pub fn get_instructions(&self) -> HashMap<(String, bool), TuringInstruction> {
+    pub fn get_instructions(&self) -> Result<HashMap<(String, bool), TuringInstruction>, CompilerError> {
         let mut instructions: HashMap<(String, bool), TuringInstruction> = HashMap::new();
 
         let file = match TuringParser::parse(Rule::instructions, self.code.as_ref()) {
@@ -32,14 +32,17 @@ impl Library {
         };
 
         for record in file.into_inner() {
-            let tmp = TuringInstruction::from(record.into_inner());
+            let tmp = match TuringInstruction::from(record.into_inner()) {
+                Ok(i) => i,
+                Err(e) => return Err(e),
+            };
             instructions.insert(
                 (tmp.from_state.clone(), tmp.from_value.clone()),
                 tmp.clone(),
             );
         }
 
-        instructions
+        Ok(instructions)
     }
 }
 
@@ -351,7 +354,7 @@ mod test_composition {
     /// (should not panic)
     fn libraries() {
         for lib in LIBRARIES {
-            lib.get_instructions();
+            let _ = lib.get_instructions();
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,6 +293,8 @@ mod test_parsing {
 #[cfg(test)]
 mod test_composition {
     use crate::Rule;
+    use crate::TuringMachine;
+    use crate::TuringOutput;
     use crate::TuringParser;
     use crate::LIBRARIES;
     use pest::{consumes_to, parses_to};
@@ -345,11 +347,41 @@ mod test_composition {
     }
 
     #[test]
-    // Test that all the libraries are correctly parsed
-    // (should not panic)
+    /// Test that all the libraries are correctly parsed
+    /// (should not panic)
     fn libraries() {
         for lib in LIBRARIES {
             lib.get_instructions();
         }
+    }
+
+    #[test]
+    /// Test compiling a program that uses composition and nothing else (no extra code)
+    /// Also tests that you can write the `compose`, tape (`{111011}`), initial state (`I = {q0}`) and final state (`F = {q2}`) in any order
+    fn composition() {
+        let test = "
+        compose = {sum};
+        
+        F = {q2};
+        {111011};
+        I = {q0};
+        ";
+
+        let mut tm = match TuringMachine::new(test) {
+            Ok(t) => t.0,
+            Err(e) => {
+                println!("{:?}", e);
+                std::process::exit(1);
+            }
+        };
+
+        assert_eq!(tm.final_result(), TuringOutput::Defined((5, 3)));
+
+        assert_eq!(
+            tm.to_string(),
+            "0 0 0 0 1 1 0 0 1 0 0 \n              ^       "
+        );
+
+        
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,9 @@ pub struct Library {
 }
 
 impl Library {
-    pub fn get_instructions(&self) -> Result<HashMap<(String, bool), TuringInstruction>, CompilerError> {
+    pub fn get_instructions(
+        &self,
+    ) -> Result<HashMap<(String, bool), TuringInstruction>, CompilerError> {
         let mut instructions: HashMap<(String, bool), TuringInstruction> = HashMap::new();
 
         let file = match TuringParser::parse(Rule::instructions, self.code.as_ref()) {
@@ -384,7 +386,5 @@ mod test_composition {
             tm.to_string(),
             "0 0 0 0 1 1 0 0 1 0 0 \n              ^       "
         );
-
-        
     }
 }

--- a/src/turing.rs
+++ b/src/turing.rs
@@ -148,7 +148,10 @@ impl TuringMachine {
                                 if let Some(library) = lib {
                                     debug!("Found the library, composing...");
 
-                                    instructions.extend(library.get_instructions());
+                                    instructions.extend(match library.get_instructions() {
+                                        Ok(i) => i,
+                                        Err(c_err) => return Err(c_err),
+                                    });
 
                                     composed.push(library.clone());
                                 } else {
@@ -177,7 +180,10 @@ impl TuringMachine {
                     }
                 }
                 Rule::instruction => {
-                    let tmp = TuringInstruction::from(record.into_inner());
+                    let tmp = match TuringInstruction::from(record.into_inner()) {
+                        Ok(i) => i,
+                        Err(c_err) => return Err(c_err),
+                    };
 
                     if instructions.contains_key(&(tmp.from_state.clone(), tmp.from_value.clone()))
                     {
@@ -203,6 +209,30 @@ impl TuringMachine {
                     warn!("Unhandled: {}", record.into_inner().as_str());
                 }
             }
+        }
+
+        if final_states.is_empty() {
+            error!("No final state given");
+
+            return Err(CompilerError::SyntaxError {
+                position: ErrorPosition::new((0, 0), None),
+                message: String::from("No final state given"),
+                code: String::from(code),
+                expected: Rule::final_state,
+                found: None,
+            });
+        }
+
+        if current_state.is_empty() {
+            error!("No initial state given");
+
+            return Err(CompilerError::SyntaxError {
+                position: ErrorPosition::new((0, 0), None),
+                message: String::from("No initial state given"),
+                code: String::from(code),
+                expected: Rule::initial_state,
+                found: None,
+            });
         }
 
         let mut tape_position = 0;
@@ -403,9 +433,12 @@ impl TuringMachine {
         self.frequencies = HashMap::new();
     }
 
-    /// Returns true if the current state is a final state
+    /// Returns true if the current state is a final state and the motion is to Halt
     pub fn finished(&self) -> bool {
-        return self.final_states.contains(&self.current_state);
+        self.final_states.contains(&self.current_state) && match self.get_current_instruction() {
+            Some(i) => i.movement == Movement::HALT,
+            None => false,
+        }
     }
 
     /// Returns the values of the tape

--- a/src/turing.rs
+++ b/src/turing.rs
@@ -467,6 +467,9 @@ impl TuringMachine {
             steps += 1;
         }
 
+        self.step();
+        steps += 1;
+
         TuringOutput::Defined((
             steps,
             self.tape.iter().map(|v| if *v { 1 } else { 0 }).sum(),

--- a/src/turing.rs
+++ b/src/turing.rs
@@ -435,10 +435,11 @@ impl TuringMachine {
 
     /// Returns true if the current state is a final state and the motion is to Halt
     pub fn finished(&self) -> bool {
-        self.final_states.contains(&self.current_state) && match self.get_current_instruction() {
-            Some(i) => i.movement == Movement::HALT,
-            None => false,
-        }
+        self.final_states.contains(&self.current_state)
+            && match self.get_current_instruction() {
+                Some(i) => i.movement == Movement::HALT,
+                None => false,
+            }
     }
 
     /// Returns the values of the tape

--- a/turing.pest
+++ b/turing.pest
@@ -9,10 +9,26 @@ description = @{ SOI ~ ("/" ~ COMMENT)? }
 tape = { "{" ~ value* ~ "}" ~ ";" }
 final_state = { "F" ~ "=" ~ "{" ~ state ~ ("," ~ state)* ~ "}" ~ ";" }
 initial_state = { "I" ~ "=" ~ "{" ~ state ~ "}" ~ ";" }
+
+initial_params = _{
+    ( tape | initial_state | final_state ) |
+    ( tape | initial_state | final_state | composition)
+}
+
+// Silent rule to accept the initial parameters in any order
+// The composition rule is optional
+definition = _{
+    PUSH(initial_params)
+    ~ (
+      !PEEK_ALL
+      ~ PUSH(initial_params)
+    ){2, 3}
+  }
+
 function_name = @{ ASCII_ALPHA_LOWER ~ (ASCII_ALPHANUMERIC | "_")* }
 composition = { "compose" ~ "=" ~ "{" ~ ((function_name ~ ",")*  ~ function_name) ~ "}" ~ ";"}
 instruction = { "(" ~ state ~ "," ~ value ~ "," ~ value ~ "," ~ movement ~ "," ~ state ~ ")" ~ ";" }
 
 instructions = { instruction+ }
 
-file = { description ~ tape ~ initial_state ~ final_state ~ composition? ~ instruction+ ~ EOI }
+file = { description ~ definition ~ instruction* ~ EOI }

--- a/turing.pest
+++ b/turing.pest
@@ -10,9 +10,12 @@ tape = { "{" ~ value* ~ "}" ~ ";" }
 final_state = { "F" ~ "=" ~ "{" ~ state ~ ("," ~ state)* ~ "}" ~ ";" }
 initial_state = { "I" ~ "=" ~ "{" ~ state ~ "}" ~ ";" }
 
+
+function_name = @{ ASCII_ALPHA_LOWER ~ (ASCII_ALPHANUMERIC | "_")* }
+composition = { "compose" ~ "=" ~ "{" ~ ((function_name ~ ",")*  ~ function_name) ~ "}" ~ ";"}
+
 initial_params = _{
-    ( tape | initial_state | final_state ) |
-    ( tape | initial_state | final_state | composition)
+    tape | initial_state | final_state | composition?
 }
 
 // Silent rule to accept the initial parameters in any order
@@ -22,11 +25,9 @@ definition = _{
     ~ (
       !PEEK_ALL
       ~ PUSH(initial_params)
-    ){2, 3}
+    ){3}
   }
 
-function_name = @{ ASCII_ALPHA_LOWER ~ (ASCII_ALPHANUMERIC | "_")* }
-composition = { "compose" ~ "=" ~ "{" ~ ((function_name ~ ",")*  ~ function_name) ~ "}" ~ ";"}
 instruction = { "(" ~ state ~ "," ~ value ~ "," ~ value ~ "," ~ movement ~ "," ~ state ~ ")" ~ ";" }
 
 instructions = { instruction+ }


### PR DESCRIPTION
### Added
- Syntax support for wrinting the definitions (`I`, `F`, `compose` and the tape) in any order.
- Error handling for when there are no final states or no intial state.

### Changed
- Updated minor version of dependencies
- Now parsing an instruction can return an error if the instruction is not valid.
- Now defining instructions is optional. If no instructions are defined, the turing machine will be empty apart from the composed libraries.

### Fixed
- Syntax support for the movements `I` (Izquierda) and `D` (Derecha).
- The `finished` function now takes into account the movement in addition to whether the state is final or not.